### PR TITLE
feat: Upgrade project dependencies to latest versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,21 +10,21 @@ repositories {
 }
 
 dependencies {
-    implementation("io.github.java-native:jssc:2.9.6")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
+    implementation("io.github.java-native:jssc:2.10.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
 
 
 
-    implementation("org.slf4j:slf4j-simple:1.7.36")
-    implementation("org.slf4j:slf4j-api:1.7.36")
+    implementation("org.slf4j:slf4j-simple:2.0.17")
+    implementation("org.slf4j:slf4j-api:2.0.17")
     // testImplementation(kotlin("test"))
 
     // https://mvnrepository.com/artifact/org.bytedeco/javacv
-    implementation("org.bytedeco:javacv:1.5.11")
+    implementation("org.bytedeco:javacv:1.5.12")
     // https://mvnrepository.com/artifact/org.bytedeco/javacv-platform
-    implementation("org.bytedeco:javacv-platform:1.5.11")
+    implementation("org.bytedeco:javacv-platform:1.5.12")
     // https://mvnrepository.com/artifact/org.bytedeco/opencv
-    implementation("org.bytedeco:opencv:4.10.0-1.5.11")
+    implementation("org.bytedeco:opencv:4.11.0-1.5.12")
 
     // https://mvnrepository.com/artifact/org.openpnp/opencv
     // implementation("org.openpnp:opencv:4.9.0-0")


### PR DESCRIPTION
Upgraded the following dependencies to their latest compatible versions:
- org.bytedeco:javacv: 1.5.11 -> 1.5.12
- org.bytedeco:javacv-platform: 1.5.11 -> 1.5.12
- org.bytedeco:opencv: 4.10.0-1.5.11 -> 4.11.0-1.5.12
- org.slf4j:slf4j-simple: 1.7.36 -> 2.0.17
- org.slf4j:slf4j-api: 1.7.36 -> 2.0.17
- io.github.java-native:jssc: 2.9.6 -> 2.10.2
- org.jetbrains.kotlinx:kotlinx-coroutines-core: 1.10.1 -> 1.10.2

The project builds successfully with the new versions.